### PR TITLE
Code cleanup

### DIFF
--- a/docs/customDSL.md
+++ b/docs/customDSL.md
@@ -31,7 +31,7 @@ createStyle(18.0) { }
 Code fonts do not inherit this global setting, instead, they default to use `FontFamily("monospace")` configured on the
 user's device.
 
-**Default:** `FontFamily("sans-serif")`
+**Default:** `FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)`
 
 ```kotlin
 createStyle(baseFontFamily = FontFamily("Roboto", "Lato")) { }
@@ -69,7 +69,7 @@ paragraph {
 ### Font Family
 **Data type:** `FontFamily`
 
-**Default:** `FontFamily("sans-serif")`
+**Default:** `FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)`
 
 ```kotlin
 paragraph {

--- a/src/main/kotlin/me/chill/rendering/PDFStyleProvider.kt
+++ b/src/main/kotlin/me/chill/rendering/PDFStyleProvider.kt
@@ -3,10 +3,8 @@ package me.chill.rendering
 import me.chill.style.InlineStyleRenderer
 import me.chill.style.PDFStyle
 import me.chill.style.elements.Element
-import me.chill.style.elements.lists.UnorderedList
 import me.chill.utility.cssColor
 import me.chill.utility.px
-import org.bouncycastle.crypto.tls.ExtensionType
 import org.commonmark.node.*
 import org.commonmark.renderer.html.AttributeProvider
 import org.commonmark.renderer.html.HtmlRenderer
@@ -34,7 +32,7 @@ class PDFStyleProvider(private val style: PDFStyle) : AttributeProvider {
 
       is StrongEmphasis -> inlineStyleRenderer.setStyle(style.bold)
 
-      is Paragraph -> inlineStyleRenderer.setStyle(style.paragraph)
+      is Paragraph -> inlineStyleRenderer.setStyle(style.p)
 
       is Link -> inlineStyleRenderer.setStyle(style.link)
 

--- a/src/main/kotlin/me/chill/style/FontFamily.kt
+++ b/src/main/kotlin/me/chill/style/FontFamily.kt
@@ -6,6 +6,15 @@ package me.chill.style
  */
 class FontFamily(private vararg val fonts: String) {
 
+  enum class BaseFontFamily {
+    SERIF, SANS_SERIF, CURSIVE, FANTASY, MONOSPACE;
+
+    fun toCss() = name.toLowerCase().replace("_", "-")
+  }
+
+  constructor(fallBackFont: BaseFontFamily, vararg fonts: String)
+      : this(*fonts.toMutableList().apply { add(fallBackFont.toCss()) }.toTypedArray())
+
   private val fontFamily = mutableListOf<String>()
 
   init {

--- a/src/main/kotlin/me/chill/style/PDFStyle.kt
+++ b/src/main/kotlin/me/chill/style/PDFStyle.kt
@@ -1,6 +1,11 @@
 package me.chill.style
 
-import me.chill.style.elements.*
+import me.chill.style.FontFamily.BaseFontFamily.MONOSPACE
+import me.chill.style.FontFamily.BaseFontFamily.SANS_SERIF
+import me.chill.style.elements.Bold
+import me.chill.style.elements.InlineCode
+import me.chill.style.elements.Link
+import me.chill.style.elements.Paragraph
 import me.chill.style.elements.headers.*
 import me.chill.style.elements.lists.OrderedList
 import me.chill.style.elements.lists.UnorderedList
@@ -17,7 +22,7 @@ import me.chill.style.elements.lists.UnorderedList
  */
 class PDFStyle(
   private val baseFontSize: Double = 16.0,
-  private val baseFontFamily: FontFamily = FontFamily("sans-serif")
+  private val baseFontFamily: FontFamily = FontFamily(SANS_SERIF)
 ) {
 
   var h1 = HeaderOne(baseFontSize, baseFontFamily.clone())
@@ -38,7 +43,7 @@ class PDFStyle(
   var h6 = HeaderSix(baseFontSize, baseFontFamily.clone())
     private set
 
-  var inlineCode = InlineCode(baseFontSize, FontFamily("monospace").clone())
+  var inlineCode = InlineCode(baseFontSize, FontFamily(MONOSPACE).clone())
     private set
 
   var bold = Bold(baseFontSize, baseFontFamily.clone())
@@ -65,13 +70,13 @@ class PDFStyle(
      */
     fun createStyle(
       baseFontSize: Double = 16.0,
-      baseFontFamily: FontFamily = FontFamily("sans-serif"),
+      baseFontFamily: FontFamily = FontFamily(SANS_SERIF),
       styleFunction: PDFStyle.() -> Unit
     ) = PDFStyle(baseFontSize, baseFontFamily.clone()).apply { styleFunction() }
   }
 
   fun inlineCode(style: InlineCode.() -> Unit) {
-    this.inlineCode = InlineCode(baseFontSize, FontFamily("monospace").clone()).apply { style() }
+    this.inlineCode = InlineCode(baseFontSize, FontFamily(MONOSPACE).clone()).apply { style() }
   }
 
   fun bold(style: Bold.() -> Unit) {

--- a/src/main/kotlin/me/chill/style/PDFStyle.kt
+++ b/src/main/kotlin/me/chill/style/PDFStyle.kt
@@ -11,7 +11,7 @@ import me.chill.style.elements.lists.OrderedList
 import me.chill.style.elements.lists.UnorderedList
 
 /**
- * Default styling for an exported PDF.
+ * Styling for an exported PDF.
  *
  * Supply a [baseFontSize] to be applied to all elements unless otherwise
  * specified. This [baseFontSize] will influence the scaling of each
@@ -24,6 +24,20 @@ class PDFStyle(
   private val baseFontSize: Double = 16.0,
   private val baseFontFamily: FontFamily = FontFamily(SANS_SERIF)
 ) {
+
+  companion object {
+    /**
+     * Creates a custom PDFStyle object using the DSL.
+     *
+     * Supply a [baseFontSize] to be applied to all element unless otherwise specified.
+     * [baseFontSize] will influence the scaling of each header.
+     */
+    fun createStyle(
+      baseFontSize: Double = 16.0,
+      baseFontFamily: FontFamily = FontFamily(SANS_SERIF),
+      styleFunction: PDFStyle.() -> Unit
+    ) = PDFStyle(baseFontSize, baseFontFamily.clone()).apply { styleFunction() }
+  }
 
   var h1 = HeaderOne(baseFontSize, baseFontFamily.clone())
     private set
@@ -49,7 +63,7 @@ class PDFStyle(
   var bold = Bold(baseFontSize, baseFontFamily.clone())
     private set
 
-  var paragraph = Paragraph(baseFontSize, baseFontFamily.clone())
+  var p = Paragraph(baseFontSize, baseFontFamily.clone())
     private set
 
   var link = Link(baseFontSize, baseFontFamily.clone())
@@ -61,67 +75,65 @@ class PDFStyle(
   var ol = OrderedList(baseFontSize, baseFontFamily.clone())
     private set
 
-  companion object {
-    /**
-     * Creates a custom PDFStyle object using a custom DSL.
-     *
-     * Supply a [baseFontSize] to be applied to all element unless otherwise specified.
-     * [baseFontSize] will influence the scaling of each header.
-     */
-    fun createStyle(
-      baseFontSize: Double = 16.0,
-      baseFontFamily: FontFamily = FontFamily(SANS_SERIF),
-      styleFunction: PDFStyle.() -> Unit
-    ) = PDFStyle(baseFontSize, baseFontFamily.clone()).apply { styleFunction() }
-  }
+  /**
+   * Style [InlineCode] element.
+   */
+  fun inlineCode(style: InlineCode.() -> Unit) = inlineCode.style()
 
-  fun inlineCode(style: InlineCode.() -> Unit) {
-    this.inlineCode = InlineCode(baseFontSize, FontFamily(MONOSPACE).clone()).apply { style() }
-  }
+  /**
+   * Style [Bold] element.
+   */
+  fun bold(style: Bold.() -> Unit) = bold.style()
 
-  fun bold(style: Bold.() -> Unit) {
-    this.bold = Bold(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [Paragraph] element.
+   */
+  fun p(style: Paragraph.() -> Unit) = p.style()
 
-  fun paragraph(style: Paragraph.() -> Unit) {
-    this.paragraph = Paragraph(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [Link] element.
+   */
+  fun link(style: Link.() -> Unit) = link.style()
 
-  fun link(style: Link.() -> Unit) {
-    this.link = Link(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [UnorderedList] element.
+   */
+  fun ul(style: UnorderedList.() -> Unit) = ul.style()
 
-  fun h1(style: HeaderOne.() -> Unit) {
-    this.h1 = HeaderOne(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [OrderedList] element.
+   */
+  fun ol(style: OrderedList.() -> Unit) = ol.style()
 
-  fun h2(style: HeaderTwo.() -> Unit) {
-    this.h2 = HeaderTwo(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [HeaderOne] element.
+   */
+  fun h1(style: HeaderOne.() -> Unit) = h1.style()
 
-  fun h3(style: HeaderThree.() -> Unit) {
-    this.h3 = HeaderThree(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [HeaderTwo] element.
+   */
+  fun h2(style: HeaderTwo.() -> Unit) = h2.style()
 
-  fun h4(style: HeaderFour.() -> Unit) {
-    this.h4 = HeaderFour(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [HeaderThree] element.
+   */
+  fun h3(style: HeaderThree.() -> Unit) = h3.style()
 
-  fun h5(style: HeaderFive.() -> Unit) {
-    this.h5 = HeaderFive(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [HeaderFour] element.
+   */
+  fun h4(style: HeaderFour.() -> Unit) = h4.style()
 
-  fun h6(style: HeaderSix.() -> Unit) {
-    this.h6 = HeaderSix(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [HeaderFive] element.
+   */
+  fun h5(style: HeaderFive.() -> Unit) = h5.style()
 
-  fun ul(style: UnorderedList.() -> Unit) {
-    this.ul = UnorderedList(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
-
-  fun ol(style: OrderedList.() -> Unit) {
-    this.ol = OrderedList(baseFontSize, baseFontFamily.clone()).apply { style() }
-  }
+  /**
+   * Style [HeaderSix] element.
+   */
+  fun h6(style: HeaderSix.() -> Unit) = h6.style()
 
   fun matchHeaderLevel(headerLevel: Int) =
     when (headerLevel) {

--- a/src/main/kotlin/me/chill/style/elements/Bold.kt
+++ b/src/main/kotlin/me/chill/style/elements/Bold.kt
@@ -1,10 +1,11 @@
 package me.chill.style.elements
 
 import me.chill.style.FontFamily
+import me.chill.style.FontFamily.BaseFontFamily.SANS_SERIF
 
 class Bold(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(SANS_SERIF)
 ) : Element(fontSize, fontFamily) {
   override var fontWeight = FontWeight.BOLD
 }

--- a/src/main/kotlin/me/chill/style/elements/Element.kt
+++ b/src/main/kotlin/me/chill/style/elements/Element.kt
@@ -2,7 +2,7 @@ package me.chill.style.elements
 
 import me.chill.style.Border
 import me.chill.style.FontFamily
-import me.chill.utility.px
+import me.chill.style.FontFamily.BaseFontFamily.SANS_SERIF
 import java.awt.Color
 
 /**
@@ -10,7 +10,7 @@ import java.awt.Color
  */
 open class Element(
   open var fontSize: Double,
-  open var fontFamily: FontFamily = FontFamily("sans-serif")
+  open var fontFamily: FontFamily = FontFamily(SANS_SERIF)
 ) {
 
   open var fontColor: Color? = Color.BLACK

--- a/src/main/kotlin/me/chill/style/elements/InlineCode.kt
+++ b/src/main/kotlin/me/chill/style/elements/InlineCode.kt
@@ -1,16 +1,15 @@
 package me.chill.style.elements
 
 import me.chill.style.FontFamily
+import me.chill.style.FontFamily.BaseFontFamily.MONOSPACE
 import me.chill.utility.c
-import me.chill.utility.px
-import java.awt.Color
 
 /**
  * Inline <code> element styles.
  */
 class InlineCode(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("monospace")
+  fontFamily: FontFamily = FontFamily(MONOSPACE)
 ) : Element(fontSize, fontFamily) {
   override var fontColor = c("FF3D00")
   override var backgroundColor = c("#F5F5F5")

--- a/src/main/kotlin/me/chill/style/elements/Link.kt
+++ b/src/main/kotlin/me/chill/style/elements/Link.kt
@@ -6,7 +6,7 @@ import java.awt.Color
 
 class Link(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : Element(fontSize, fontFamily) {
   override var textDecoration = TextDecoration.UNDERLINE
   override var fontColor: Color? = c("448AFF")

--- a/src/main/kotlin/me/chill/style/elements/Paragraph.kt
+++ b/src/main/kotlin/me/chill/style/elements/Paragraph.kt
@@ -4,5 +4,5 @@ import me.chill.style.FontFamily
 
 class Paragraph(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : Element(fontSize, fontFamily)

--- a/src/main/kotlin/me/chill/style/elements/headers/Header.kt
+++ b/src/main/kotlin/me/chill/style/elements/headers/Header.kt
@@ -5,7 +5,7 @@ import me.chill.style.elements.Element
 
 open class Header(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif"),
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF),
   headerScaleFactor: Double = 1.0
 ) : Element(fontSize, fontFamily) {
   override var fontWeight = FontWeight.BOLD

--- a/src/main/kotlin/me/chill/style/elements/headers/HeaderFive.kt
+++ b/src/main/kotlin/me/chill/style/elements/headers/HeaderFive.kt
@@ -5,5 +5,5 @@ import me.chill.style.elements.Element
 
 class HeaderFive(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : Header(fontSize, fontFamily, 0.83)

--- a/src/main/kotlin/me/chill/style/elements/headers/HeaderFour.kt
+++ b/src/main/kotlin/me/chill/style/elements/headers/HeaderFour.kt
@@ -5,5 +5,5 @@ import me.chill.style.elements.Element
 
 class HeaderFour(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : Header(fontSize, fontFamily)

--- a/src/main/kotlin/me/chill/style/elements/headers/HeaderOne.kt
+++ b/src/main/kotlin/me/chill/style/elements/headers/HeaderOne.kt
@@ -4,5 +4,5 @@ import me.chill.style.FontFamily
 
 class HeaderOne(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : Header(fontSize, fontFamily, 2.0)

--- a/src/main/kotlin/me/chill/style/elements/headers/HeaderSix.kt
+++ b/src/main/kotlin/me/chill/style/elements/headers/HeaderSix.kt
@@ -5,5 +5,5 @@ import me.chill.style.elements.Element
 
 class HeaderSix(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : Header(fontSize, fontFamily, 0.67)

--- a/src/main/kotlin/me/chill/style/elements/headers/HeaderThree.kt
+++ b/src/main/kotlin/me/chill/style/elements/headers/HeaderThree.kt
@@ -5,5 +5,5 @@ import me.chill.style.elements.Element
 
 class HeaderThree(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : Header(fontSize, fontFamily, 1.17)

--- a/src/main/kotlin/me/chill/style/elements/headers/HeaderTwo.kt
+++ b/src/main/kotlin/me/chill/style/elements/headers/HeaderTwo.kt
@@ -5,5 +5,5 @@ import me.chill.style.elements.Element
 
 class HeaderTwo(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : Header(fontSize, fontFamily, 1.5)

--- a/src/main/kotlin/me/chill/style/elements/lists/List.kt
+++ b/src/main/kotlin/me/chill/style/elements/lists/List.kt
@@ -5,7 +5,7 @@ import me.chill.style.elements.Element
 
 open class List(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : Element(fontSize, fontFamily) {
 
   open var listStyleType = ListStyleType.CIRCLE

--- a/src/main/kotlin/me/chill/style/elements/lists/OrderedList.kt
+++ b/src/main/kotlin/me/chill/style/elements/lists/OrderedList.kt
@@ -4,7 +4,7 @@ import me.chill.style.FontFamily
 
 class OrderedList(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : List(fontSize, fontFamily) {
   override var listStyleType = ListStyleType.DECIMAL
 }

--- a/src/main/kotlin/me/chill/style/elements/lists/UnorderedList.kt
+++ b/src/main/kotlin/me/chill/style/elements/lists/UnorderedList.kt
@@ -4,7 +4,7 @@ import me.chill.style.FontFamily
 
 class UnorderedList(
   fontSize: Double = 16.0,
-  fontFamily: FontFamily = FontFamily("sans-serif")
+  fontFamily: FontFamily = FontFamily(FontFamily.BaseFontFamily.SANS_SERIF)
 ) : List(fontSize, fontFamily) {
   override var listStyleType = List.ListStyleType.CIRCLE
 }

--- a/src/test/kotlin/me/chill/style/FontFamilyTest.kt
+++ b/src/test/kotlin/me/chill/style/FontFamilyTest.kt
@@ -36,9 +36,20 @@ class FontFamilyTest {
 
   @Test
   fun `FontFamily toString will return the font family in CSS font-family format`() {
-    val fontFamily = FontFamily("Fira Code", "Roboto", "Raleway")
-    val expectedString = "'Fira Code', Roboto, Raleway"
-    assertEquals(expectedString, fontFamily.toString())
+    val fontFamily = FontFamily("Roboto", "Raleway")
+    val expectedString = "Roboto, Raleway"
+    fontFamily.checkToString(expectedString)
+  }
+
+  @Test
+  fun `FontFamily toString adds single quotes to font names with more than 2 words`() {
+    val fontFamily = FontFamily("Fira Code", "Roboto", "Raleway", "Droid Sans Mono")
+    val expectedString = "'Fira Code', Roboto, Raleway, 'Droid Sans Mono'"
+    fontFamily.checkToString(expectedString)
+  }
+
+  private fun FontFamily.checkToString(expectedToString: String) {
+    assertEquals(expectedToString, toString())
   }
 
   private fun FontFamily.checkFontFamilySize(expectedSize: Int) {

--- a/src/test/kotlin/me/chill/style/FontFamilyTest.kt
+++ b/src/test/kotlin/me/chill/style/FontFamilyTest.kt
@@ -5,15 +5,25 @@ import kotlin.test.assertEquals
 
 class FontFamilyTest {
   @Test
-  fun `Creating FontFamily with empty fonts parameter leaves fonts empty`() {
+  fun `Empty FontFamily loads no fonts`() {
     val fontFamily = FontFamily()
     fontFamily.checkFontFamilySize(0)
   }
 
   @Test
-  fun `Creating FontFamily with some fonts will load those fonts into the FontFamily`() {
+  fun `FontFamily with some fonts loads those fonts`() {
     val fontFamily = FontFamily("Roboto", "Arial", "Consolas")
     fontFamily.checkFontList("Roboto", "Arial", "Consolas")
+  }
+
+  @Test
+  fun `FontFamily adds fallback font to the end of the font list`() {
+    val fontFamily = FontFamily(
+      FontFamily.BaseFontFamily.SANS_SERIF,
+      "Roboto",
+      "Lato"
+    )
+    fontFamily.checkFontList("Roboto", "Lato", "sans-serif")
   }
 
   @Test


### PR DESCRIPTION
**FontFamily:**
`FontFamily.BaseFontFamily` enumeration created to allow fallback fonts without worrying about screwing up those constants.

Created a secondary constructor to allow for a single fallbackfont to be added to the end of the font stack if necessary.

**PDFStyle:**
1. `PDFStyle#paragraph` -> `PDFStyle#p`
2. DSL methods modify the base element instead of creating a new one:

    ```kotlin
    fun p(style: Paragraph.() -> Unit) = p.style()
    // instead of
    fun p(style: Paragraph.() -> Unit) {
        this.p = Paragraph(baseFontSize, baseFontFamily.clone()).apply { style() }
    }
    ```

3. Simple documentation added to each DSL method