### PR TITLE
Inline code refinements

### DIFF
--- a/src/main/kotlin/me/chill/rendering/PDFStyleProvider.kt
+++ b/src/main/kotlin/me/chill/rendering/PDFStyleProvider.kt
@@ -25,8 +25,8 @@ class PDFStyleProvider(private val style: PDFStyle) : AttributeProvider {
         with(style.inlineCode) {
           inlineStyleRenderer
             .setStyle(this)
-            .attribute("border-radius", borderRadius.px)
-            .attribute("padding", padding.px)
+            .attribute("border-radius", borderRadius.toCss { it.px })
+            .attribute("padding", padding.toCss { it.px })
         }
       }
 
@@ -43,7 +43,7 @@ class PDFStyleProvider(private val style: PDFStyle) : AttributeProvider {
           else -> style.ul
         }
 
-        with (listType) {
+        with(listType) {
           inlineStyleRenderer
             .setStyle(this)
             .attribute("list-style-type", listStyleType.toCss())

--- a/src/main/kotlin/me/chill/rendering/PDFStyleProvider.kt
+++ b/src/main/kotlin/me/chill/rendering/PDFStyleProvider.kt
@@ -25,7 +25,6 @@ class PDFStyleProvider(private val style: PDFStyle) : AttributeProvider {
         with(style.inlineCode) {
           inlineStyleRenderer
             .setStyle(this)
-            .attribute("border-radius", borderRadius.toCss { it.px })
             .attribute("padding", padding.toCss { it.px })
         }
       }
@@ -64,5 +63,6 @@ class PDFStyleProvider(private val style: PDFStyle) : AttributeProvider {
       attribute("font-weight", fontWeight.name.toLowerCase())
       attribute("text-decoration", textDecoration.toCss())
       attribute("border", border)
+      attribute("border-radius", border.borderRadius.toCss { it.px })
     }
 }

--- a/src/main/kotlin/me/chill/style/Border.kt
+++ b/src/main/kotlin/me/chill/style/Border.kt
@@ -1,6 +1,7 @@
 package me.chill.style
 
 import me.chill.style.Border.BorderStyle.*
+import me.chill.style.elements.Box
 import me.chill.utility.cssColor
 import me.chill.utility.px
 import java.awt.Color
@@ -12,8 +13,10 @@ import java.awt.Color
 data class Border(
   var borderWidth: Double = 0.0,
   var borderStyle: BorderStyle = NONE,
-  var borderColor: Color? = Color.BLACK
+  var borderColor: Color? = Color.BLACK,
+  var borderRadius: Box<Double> = Box(0.0)
 ) {
+
   enum class BorderStyle {
     DOTTED,
     DASHED,
@@ -79,17 +82,23 @@ data class Border(
 
   /**
    * Resets the border to defaults of [borderWidth] - 0.0, [borderStyle] - [NONE],
-   * [borderColor] - [Color.BLACK].
+   * [borderColor] - [Color.BLACK], [borderRadius] - `Box(0.0)`.
    */
-  fun clearBorder() = setBorder(0.0, NONE, Color.BLACK)
+  fun clearBorder() = setBorder(0.0, NONE, Color.BLACK, Box(0.0))
 
   /**
    * Sets the border preferences.
    */
-  private fun setBorder(borderWidth: Double, borderStyle: BorderStyle, borderColor: Color?) {
+  private fun setBorder(
+    borderWidth: Double,
+    borderStyle: BorderStyle,
+    borderColor: Color?,
+    borderRadius: Box<Double> = this.borderRadius
+  ) {
     this.borderWidth = borderWidth
     this.borderStyle = borderStyle
     this.borderColor = borderColor
+    this.borderRadius = borderRadius
   }
 
   override fun toString() = "${borderWidth.px} ${borderStyle.name.toLowerCase()} ${borderColor?.cssColor()}"

--- a/src/main/kotlin/me/chill/style/elements/Box.kt
+++ b/src/main/kotlin/me/chill/style/elements/Box.kt
@@ -1,0 +1,14 @@
+package me.chill.style.elements
+
+/**
+ * Box of measurements for all directions.
+ */
+class Box<T>(val top: T, val right: T, val bottom: T, val left: T) {
+  constructor(vertical: T, horizontal: T) : this(vertical, horizontal, vertical, horizontal)
+  constructor(all: T) : this(all, all, all, all)
+
+  fun toCss() = "$top $right $bottom $left"
+
+  fun <P> toCss(modification: (T) -> P) =
+    "${modification(top)} ${modification(right)} ${modification(bottom)} ${modification(left)}"
+}

--- a/src/main/kotlin/me/chill/style/elements/InlineCode.kt
+++ b/src/main/kotlin/me/chill/style/elements/InlineCode.kt
@@ -6,6 +6,10 @@ import me.chill.utility.c
 
 /**
  * Inline <code> element styles.
+ *
+ * **Customizations:**
+ * - [borderRadius]
+ * - [padding]
  */
 class InlineCode(
   fontSize: Double = 16.0,
@@ -13,6 +17,6 @@ class InlineCode(
 ) : Element(fontSize, fontFamily) {
   override var fontColor = c("FF3D00")
   override var backgroundColor = c("#F5F5F5")
-  var borderRadius = 5.0
-  var padding = 3.0
+  var borderRadius = Box(5.0)
+  var padding = Box(3.0)
 }

--- a/src/main/kotlin/me/chill/style/elements/InlineCode.kt
+++ b/src/main/kotlin/me/chill/style/elements/InlineCode.kt
@@ -8,7 +8,6 @@ import me.chill.utility.c
  * Inline <code> element styles.
  *
  * **Customizations:**
- * - [borderRadius]
  * - [padding]
  */
 class InlineCode(
@@ -17,6 +16,5 @@ class InlineCode(
 ) : Element(fontSize, fontFamily) {
   override var fontColor = c("FF3D00")
   override var backgroundColor = c("#F5F5F5")
-  var borderRadius = Box(5.0)
   var padding = Box(3.0)
 }

--- a/src/test/kotlin/me/chill/style/BorderTest.kt
+++ b/src/test/kotlin/me/chill/style/BorderTest.kt
@@ -1,6 +1,7 @@
 package me.chill.style
 
 import me.chill.style.Border.BorderStyle.*
+import me.chill.style.elements.Box
 import me.chill.utility.c
 import org.junit.Test
 import java.awt.Color
@@ -8,27 +9,39 @@ import kotlin.test.assertEquals
 
 class BorderTest {
   @Test
-  fun `Default border is 0 width, black color and NONE`() {
-    with (Border()) {
-      checkBorderSettings(0.0, NONE, Color.BLACK)
+  fun `Default border is 0 width, black color, NONE and 0 radius`() {
+    with(Border()) {
+      checkBorderSettings(0.0, NONE, Color.BLACK, Box(0.0))
+    }
+  }
+
+  @Test
+  fun `DSL sets borderRadius to respective value`() {
+    with(Border()) {
+      border {
+        borderRadius = Box(3.2)
+      }
+
+      checkBorderSettings(0.0, NONE, Color.BLACK, Box(3.2))
     }
   }
 
   @Test
   fun `DSL sets border style to respective value`() {
-    Border.BorderStyle
+    Border
+      .BorderStyle
       .values()
       .forEach { it.testDSL() }
   }
 
   @Test
   fun `clearBorder resets border to default`() {
-    with (Border()) {
+    with(Border()) {
       border {
         4.1 dashed c("EDE7F6")
       }
       clearBorder()
-      checkBorderSettings(0.0, NONE, Color.BLACK)
+      checkBorderSettings(0.0, NONE, Color.BLACK, Box(0.0))
     }
   }
 
@@ -36,7 +49,7 @@ class BorderTest {
     val borderWidth = 2.0
     val borderColor = Color.RED
 
-    with (Border()) {
+    with(Border()) {
       border {
         when (this@testDSL) {
           DOTTED -> borderWidth dotted borderColor
@@ -52,7 +65,7 @@ class BorderTest {
         }
       }
 
-      checkBorderSettings(borderWidth, this@testDSL, borderColor)
+      checkBorderSettings(borderWidth, this@testDSL, borderColor, Box(0.0))
     }
   }
 
@@ -61,10 +74,19 @@ class BorderTest {
   private fun Border.checkBorderSettings(
     borderWidth: Double,
     borderStyle: Border.BorderStyle,
-    borderColor: Color?
+    borderColor: Color?,
+    borderRadius: Box<Double>
   ) {
     assertEquals(borderWidth, this.borderWidth)
     assertEquals(borderStyle, this.borderStyle)
     assertEquals(borderColor, this.borderColor)
+    this.borderRadius.checkBoxDimensions(borderRadius)
+  }
+
+  private fun Box<Double>.checkBoxDimensions(box: Box<Double>) {
+    assertEquals(box.top, this.top)
+    assertEquals(box.right, this.right)
+    assertEquals(box.bottom, this.bottom)
+    assertEquals(box.left, this.left)
   }
 }

--- a/src/test/kotlin/me/chill/style/BoxTest.kt
+++ b/src/test/kotlin/me/chill/style/BoxTest.kt
@@ -1,0 +1,47 @@
+package me.chill.style
+
+import me.chill.style.elements.Box
+import me.chill.utility.px
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class BoxTest {
+  @Test
+  fun `Box with 4 inputs assigns to each direction`() {
+    val box = Box(5, 10, 15, 20)
+    box.checkBoxDimensions(5, 10, 15, 20)
+  }
+
+  @Test
+  fun `Box with 2 inputs assigns 2 to horizontal and 2 to vertical`() {
+    val box = Box("foo", "bar")
+    box.checkBoxDimensions("foo", "bar", "foo", "bar")
+  }
+
+  @Test
+  fun `Box with 1 input assigns the same to all directions`() {
+    val box = Box(14.3)
+    box.checkBoxDimensions(14.3, 14.3, 14.3, 14.3)
+  }
+
+  @Test
+  fun `toString without modification returns box dimensions in top-right-bottom-left order untouched`() {
+    val box = Box("foo", "bar", "baz", "fuzz")
+    val expectedOutput = "foo bar baz fuzz"
+    assertEquals(expectedOutput, box.toCss())
+  }
+
+  @Test
+  fun `toString with modification returns box dimensions in top-right-bottom-left order modified`() {
+    val box = Box(13.9, 43.7, 82.1, 9.2)
+    val expectedOutput = "13.9px 43.7px 82.1px 9.2px"
+    assertEquals(expectedOutput, box.toCss { it.px })
+  }
+
+  private fun <T> Box<T>.checkBoxDimensions(top: T, right: T, bottom: T, left: T) {
+    assertEquals(top, this.top)
+    assertEquals(right, this.right)
+    assertEquals(bottom, this.bottom)
+    assertEquals(left, this.left)
+  }
+}


### PR DESCRIPTION
Made minor refinements to the way `InlineCode` is ordered such that the `padding` attributes can be set for all 4 directions using the new `Box` class.

Moved the `borderRadius` attribute to the `Border` class to allow all elements to use it.