### PR TITLE
Removed open variables in Element class

### DIFF
--- a/src/main/kotlin/com/github/woojiahao/style/elements/BlockQuote.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/BlockQuote.kt
@@ -9,18 +9,21 @@ import com.github.woojiahao.utility.cssColor
 import java.awt.Color
 
 class BlockQuote : Element("blockquote") {
-  override var backgroundColor = c("EEEEEE")
-  override var textColor: Color? = Color.BLACK
-  override var padding: Box<Measurement<Double>>? = Box(10.0.px, 20.0.px)
-  override var border by CssProperty<BorderBox?>(
-    BorderBox(
-      Border(),
-      Border(),
-      Border(),
-      Border(5.0, SOLID, c("E0E0E0"))
+  init {
+    backgroundColor = c("EEEEEE")
+    textColor = Color.BLACK
+    padding = Box(10.0.px, 20.0.px)
+    val border by CssProperty<BorderBox?>(
+      BorderBox(
+        Border(),
+        Border(),
+        Border(),
+        Border(5.0, SOLID, c("E0E0E0"))
+      )
     )
-  )
-
+    this.border = border
+  }
+  
   override fun toCss(): String {
     css += cssSelector("blockquote > p") { attributes { "color" to textColor?.cssColor() } }
     return super.toCss()

--- a/src/main/kotlin/com/github/woojiahao/style/elements/Element.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/Element.kt
@@ -9,7 +9,7 @@ import com.github.woojiahao.utility.c
 import com.github.woojiahao.utility.cssColor
 import java.awt.Color
 
-open class Element(elementName: String) {
+open class Element(private val elementName: String) {
 
   enum class FontWeight { NORMAL, BOLD, BOLDER, LIGHTER }
 
@@ -19,19 +19,19 @@ open class Element(elementName: String) {
     fun toCss() = name.replace("_", "-").toLowerCase()
   }
 
-  open var fontSize by CssProperty(fallback = Settings.fontSize)
-  open var fontFamily by CssProperty<FontFamily?>(fallback = Settings.font)
-  open var textColor by CssProperty(c("212121"), c("EEEEEE"))
-  open var backgroundColor by CssProperty<Color?>()
-  open var fontWeight by CssProperty<FontWeight?>()
-  open var textDecoration by CssProperty<TextDecoration?>()
-  open var border by CssProperty(BorderBox(Border()))
-  open var borderRadius by CssProperty<Box<Measurement<Double>>?>()
-  open var padding by CssProperty<Box<Measurement<Double>>?>()
-  open var margin by CssProperty<Box<Measurement<Double>>?>()
+  var fontSize by CssProperty(fallback = Settings.fontSize)
+  var fontFamily by CssProperty<FontFamily?>(fallback = Settings.font)
+  var textColor by CssProperty(c("212121"), c("EEEEEE"))
+  var backgroundColor by CssProperty<Color?>()
+  var fontWeight by CssProperty<FontWeight?>()
+  var textDecoration by CssProperty<TextDecoration?>()
+  var border by CssProperty(fallback = BorderBox(Border()))
+  var borderRadius by CssProperty(fallback = Box(0.0.px))
+  var padding by CssProperty<Box<Measurement<Double>>?>()
+  var margin by CssProperty<Box<Measurement<Double>>?>()
 
-  val globalCss by lazy {
-    cssSelector(elementName) {
+  val globalCss
+    get() = cssSelector(elementName) {
       attributes {
         "font-size" to fontSize?.let { it }
         "font-family" to fontFamily
@@ -48,7 +48,6 @@ open class Element(elementName: String) {
         "border-left" to border?.left
       }
     }
-  }
 
   protected val css = mutableListOf<CssSelector>()
 

--- a/src/main/kotlin/com/github/woojiahao/style/elements/Link.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/Link.kt
@@ -3,5 +3,7 @@ package com.github.woojiahao.style.elements
 import com.github.woojiahao.utility.c
 
 class Link : Element("a") {
-  override var textColor = c("448AFF")
+  init {
+    textColor = c("448AFF")
+  }
 }

--- a/src/main/kotlin/com/github/woojiahao/style/elements/Ruler.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/Ruler.kt
@@ -8,8 +8,11 @@ import com.github.woojiahao.utility.c
 import java.awt.Color.BLACK
 
 class Ruler : Element("hr") {
-  override var border by CssProperty<BorderBox?>(
-    BorderBox(Border(1.0, SOLID, BLACK)),
-    BorderBox(Border(1.0, SOLID, c("EEEEEE")))
-  )
+  init {
+    val border by CssProperty<BorderBox?>(
+      BorderBox(Border(1.0, SOLID, BLACK)),
+      BorderBox(Border(1.0, SOLID, c("EEEEEE")))
+    )
+    this.border = border
+  }
 }

--- a/src/main/kotlin/com/github/woojiahao/style/elements/code/Code.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/code/Code.kt
@@ -6,7 +6,14 @@ import com.github.woojiahao.style.elements.Element
 import com.github.woojiahao.utility.c
 
 open class Code(elementName: String) : Element(elementName) {
-  override var fontFamily by CssProperty(fallback = Settings.monospaceFont)
-  override var textColor by CssProperty(c("073642"), c("eee8d5"))
-  override var backgroundColor by CssProperty(c("fdf6e3"), c("002b36"))
+  init {
+    val fontFamily by CssProperty(fallback = Settings.monospaceFont)
+    this.fontFamily = fontFamily
+
+    val textColor by CssProperty(c("073642"), c("eee8d5"))
+    this.textColor = textColor
+
+    val backgroundColor by CssProperty(c("fdf6e3"), c("002b36"))
+    this.backgroundColor = backgroundColor
+  }
 }

--- a/src/main/kotlin/com/github/woojiahao/style/elements/code/CodeBlock.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/code/CodeBlock.kt
@@ -6,7 +6,9 @@ import com.github.woojiahao.style.utility.Measurement
 import com.github.woojiahao.style.utility.px
 
 class CodeBlock : Code("pre") {
-  override var padding: Box<Measurement<Double>>? = Box(10.0.px)
+  init {
+    padding = Box(10.0.px)
+  }
 
   override fun toCss(): String {
     css.add(cssSelector("pre > code") { attributes { "font-family" to fontFamily } })

--- a/src/main/kotlin/com/github/woojiahao/style/elements/headers/Header.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/headers/Header.kt
@@ -5,7 +5,9 @@ import com.github.woojiahao.style.utility.*
 import com.github.woojiahao.style.utility.Measurement.Type.*
 
 open class Header(headerName: String, private val headerScaleFactor: Double = 1.0) : Element(headerName) {
-  override var fontSize = calculateScaledFontSize()
+  init {
+    fontSize = calculateScaledFontSize()
+  }
 
   private fun calculateScaledFontSize(): Measurement<Double>? {
     val scaledSize = super.fontSize?.value?.times(headerScaleFactor)

--- a/src/main/kotlin/com/github/woojiahao/style/elements/lists/List.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/lists/List.kt
@@ -36,11 +36,11 @@ open class List(private val elementName: String) : Element(elementName) {
     fun toCss() = name.toLowerCase().replace("_", "-")
   }
 
-  open var listStyleType = ListStyleType.CIRCLE
+  var listStyleType = ListStyleType.CIRCLE
 
-  open var listStylePosition = ListStylePosition.OUTSIDE
+  var listStylePosition = ListStylePosition.OUTSIDE
 
-  open var listStyleImage: String? = null
+  var listStyleImage: String? = null
 
   override fun toCss(): String {
     css.add(cssSelector(elementName) {

--- a/src/main/kotlin/com/github/woojiahao/style/elements/lists/OrderedList.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/lists/OrderedList.kt
@@ -1,5 +1,7 @@
 package com.github.woojiahao.style.elements.lists
 
 class OrderedList : List("ol") {
-  override var listStyleType = ListStyleType.DECIMAL
+  init {
+    listStyleType = ListStyleType.DECIMAL
+  }
 }

--- a/src/main/kotlin/com/github/woojiahao/style/elements/lists/UnorderedList.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/lists/UnorderedList.kt
@@ -1,5 +1,7 @@
 package com.github.woojiahao.style.elements.lists
 
 class UnorderedList : List("ul") {
-  override var listStyleType = List.ListStyleType.CIRCLE
+  init {
+    listStyleType = List.ListStyleType.CIRCLE
+  }
 }

--- a/src/main/kotlin/com/github/woojiahao/style/elements/table/TableData.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/table/TableData.kt
@@ -8,10 +8,13 @@ import com.github.woojiahao.utility.c
 import java.awt.Color
 
 class TableData : Element("td") {
-  override var border by CssProperty<BorderBox?>(
-    BorderBox(Border(1.0, SOLID, Color.BLACK)),
-    BorderBox(Border(1.0, SOLID, c("EEEEEE")))
-  )
+  init {
+    val border by CssProperty<BorderBox?>(
+      BorderBox(Border(1.0, SOLID, Color.BLACK)),
+      BorderBox(Border(1.0, SOLID, c("EEEEEE")))
+    )
+    this.border = border
 
-  override var padding: Box<Measurement<Double>>? = Box(5.0.px)
+    padding = Box(5.0.px)
+  }
 }

--- a/src/main/kotlin/com/github/woojiahao/style/elements/table/TableHeader.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/elements/table/TableHeader.kt
@@ -2,17 +2,23 @@ package com.github.woojiahao.style.elements.table
 
 import com.github.woojiahao.style.css.CssProperty
 import com.github.woojiahao.style.elements.Element
-import com.github.woojiahao.style.utility.*
+import com.github.woojiahao.style.utility.Border
 import com.github.woojiahao.style.utility.Border.BorderStyle.SOLID
+import com.github.woojiahao.style.utility.BorderBox
+import com.github.woojiahao.style.utility.Box
+import com.github.woojiahao.style.utility.px
 import com.github.woojiahao.utility.c
 import java.awt.Color
 
 class TableHeader : Element("th") {
-  override var border by CssProperty<BorderBox?>(
-    BorderBox(Border(1.0, SOLID, Color.BLACK)),
-    BorderBox(Border(1.0, SOLID, c("EEEEEE")))
-  )
+  init {
+    val border by CssProperty<BorderBox?>(
+      BorderBox(Border(1.0, SOLID, Color.BLACK)),
+      BorderBox(Border(1.0, SOLID, c("EEEEEE")))
+    )
+    this.border = border
 
-  override var fontWeight: FontWeight? = FontWeight.BOLD
-  override var padding: Box<Measurement<Double>>? = Box(5.0.px)
+    fontWeight = FontWeight.BOLD
+    padding = Box(5.0.px)
+  }
 }


### PR DESCRIPTION
Replaced all open vars with normal variables that are overwritten in the constructors of children. Turns out, there was no issue with inheritance, just me being dumb about the way globalCss was initialised - setting it to be initialised everytime a get operation is performed fixed things :D