### PR TITLE
Fixed issue 46

### DIFF
--- a/src/main/kotlin/com/github/woojiahao/style/utility/Measurement.kt
+++ b/src/main/kotlin/com/github/woojiahao/style/utility/Measurement.kt
@@ -1,5 +1,8 @@
 package com.github.woojiahao.style.utility
 
+import org.apache.commons.lang3.builder.EqualsBuilder
+import org.apache.commons.lang3.builder.HashCodeBuilder
+
 class Measurement<T : Number>(val value: T, val type: Type) {
   sealed class Type(val measurement: String) {
     class Pixel : Type("px")
@@ -9,6 +12,23 @@ class Measurement<T : Number>(val value: T, val type: Type) {
   }
 
   override fun toString() = "$value${type.measurement}"
+
+  override fun equals(other: Any?): Boolean {
+    if (other !is Measurement<*>) return false
+
+    val measurement = other as Measurement<T>
+
+    return EqualsBuilder()
+      .append(value, measurement.value)
+      .append(type.measurement, measurement.type.measurement)
+      .isEquals
+  }
+
+  override fun hashCode() =
+    HashCodeBuilder(17, 37)
+      .append(value)
+      .append(type.measurement)
+      .toHashCode()
 }
 
 val <T : Number> T.px

--- a/src/test/kotlin/com/github/woojiahao/style/BorderBoxTest.kt
+++ b/src/test/kotlin/com/github/woojiahao/style/BorderBoxTest.kt
@@ -301,8 +301,7 @@ class BorderBoxTest {
     borderStyle: Border.BorderStyle = Border.BorderStyle.NONE,
     borderColor: Color? = Color.BLACK
   ) {
-    assertEquals(borderWidth.value, this.borderWidth.value)
-    assertEquals(borderWidth.type.measurement, this.borderWidth.type.measurement)
+    assertEquals(borderWidth, this.borderWidth)
     assertEquals(borderStyle, this.borderStyle)
     assertEquals(borderColor, this.borderColor)
   }

--- a/src/test/kotlin/com/github/woojiahao/style/BorderTest.kt
+++ b/src/test/kotlin/com/github/woojiahao/style/BorderTest.kt
@@ -68,8 +68,7 @@ class BorderTest {
     borderStyle: Border.BorderStyle,
     borderColor: Color?
   ) {
-    assertEquals(borderWidth.value, this.borderWidth.value)
-    assertEquals(borderWidth.type.measurement, this.borderWidth.type.measurement)
+    assertEquals(borderWidth, this.borderWidth)
     assertEquals(borderStyle, this.borderStyle)
     assertEquals(borderColor, this.borderColor)
   }


### PR DESCRIPTION
Measurement class now overrides .equals and .hashCode to allow unit
tests to just compare 2 Measurement classes