### PR TITLE
Fixed bullet list indentation bug

### DIFF
--- a/src/main/kotlin/com/github/woojiahao/MarkdownConverter.kt
+++ b/src/main/kotlin/com/github/woojiahao/MarkdownConverter.kt
@@ -44,7 +44,6 @@ class MarkdownConverter private constructor(
     .builder()
     .extensions(extensions)
     .nodeRendererFactory { ImageNodeRenderer(markdownDocument.file, it) }
-    .nodeRendererFactory { TaskListNodeRenderer(it) }
     .build()
 
   private val tableOfContentsVisitor = TableOfContentsVisitor(documentProperties.tableOfContentsSettings)
@@ -86,12 +85,6 @@ class MarkdownConverter private constructor(
             unsafe {
               +wrap(documentStyle.getStyles())
               +wrap(pagePropertiesManager.toCss())
-              +wrap(".task-list") {
-                attributes {
-                  "list-style-type" to "none"
-                  "list-style-position" to "inside"
-                }
-              }
               +wrap(".table-of-contents") {
                 attributes {
                   "page-break-after" to "always"

--- a/src/main/kotlin/com/github/woojiahao/MarkdownConverter.kt
+++ b/src/main/kotlin/com/github/woojiahao/MarkdownConverter.kt
@@ -1,9 +1,10 @@
 package com.github.woojiahao
 
+import com.github.woojiahao.modifiers.MediaReplacedElementFactory
 import com.github.woojiahao.properties.DocumentProperties
 import com.github.woojiahao.properties.PagePropertiesManager
-import com.github.woojiahao.renderers.ImageNodeRenderer
-import com.github.woojiahao.renderers.TaskListNodeRenderer
+import com.github.woojiahao.modifiers.renderers.ImageNodeRenderer
+import com.github.woojiahao.modifiers.renderers.TaskListNodeRenderer
 import com.github.woojiahao.style.Settings
 import com.github.woojiahao.style.Style
 import com.github.woojiahao.style.css.CssSelector
@@ -17,6 +18,8 @@ import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
 import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
 import org.commonmark.ext.gfm.tables.TablesExtension
+import org.commonmark.node.BulletList
+import org.commonmark.node.Node
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
 import org.xhtmlrenderer.pdf.ITextRenderer
@@ -86,23 +89,7 @@ class MarkdownConverter private constructor(
               +wrap(".task-list") {
                 attributes {
                   "list-style-type" to "none"
-                  "margin-left" to 0.px
-                  "padding-left" to 0.px
-                }
-              }
-              +wrap(".task-list-item") {
-                attributes {
-                  "list-style-type" to "none"
-                  "margin" to 0.px
-                  "padding" to 0.px
-                }
-              }
-              +wrap(".task-list-item > input[type='checkbox']") {
-                attributes {
-                  "margin-right" to 10.px
-                  if (Settings.theme == Settings.Theme.DARK) {
-                    "background-color" to Color.WHITE.cssColor()
-                  }
+                  "list-style-position" to "inside"
                 }
               }
               +wrap(".table-of-contents") {

--- a/src/main/kotlin/com/github/woojiahao/modifiers/MediaReplacedElementFactory.kt
+++ b/src/main/kotlin/com/github/woojiahao/modifiers/MediaReplacedElementFactory.kt
@@ -1,4 +1,4 @@
-package com.github.woojiahao
+package com.github.woojiahao.modifiers
 
 import com.github.woojiahao.properties.DocumentProperties
 import com.github.woojiahao.style.utility.Box

--- a/src/main/kotlin/com/github/woojiahao/modifiers/renderers/ImageNodeRenderer.kt
+++ b/src/main/kotlin/com/github/woojiahao/modifiers/renderers/ImageNodeRenderer.kt
@@ -1,6 +1,6 @@
-package com.github.woojiahao.renderers
+package com.github.woojiahao.modifiers.renderers
 
-import com.github.woojiahao.renderers.ImageNodeRenderer.DestinationType.*
+import com.github.woojiahao.modifiers.renderers.ImageNodeRenderer.DestinationType.*
 import org.commonmark.node.Image
 import org.commonmark.node.Node
 import org.commonmark.renderer.NodeRenderer
@@ -58,7 +58,7 @@ class ImageNodeRenderer(private val document: File, context: HtmlNodeRendererCon
     val localPath = document.parent.replace("\\", "/").split("/").toMutableList()
 
     localFilePath.split("/").forEach {
-      if (it == "..") localPath.removeAt(localPath.size - 1)
+      if (it == "src/main") localPath.removeAt(localPath.size - 1)
       else localPath += it
     }
 

--- a/src/main/kotlin/com/github/woojiahao/modifiers/renderers/ImageNodeRenderer.kt
+++ b/src/main/kotlin/com/github/woojiahao/modifiers/renderers/ImageNodeRenderer.kt
@@ -15,13 +15,15 @@ class ImageNodeRenderer(private val document: File, context: HtmlNodeRendererCon
 
   private enum class DestinationType { WEB, RELATIVE_LOCAL, ABSOLUTE_LOCAL }
 
+  private val urlSeparator = "/"
+
   private val html = context.writer
 
   private val String?.isLocalFile: DestinationType
     get() {
       this ?: return WEB
 
-      with(URI(replace("\\", "/"))) {
+      with(URI(replace("\\", urlSeparator))) {
         return try {
           toURL()
           WEB
@@ -55,14 +57,18 @@ class ImageNodeRenderer(private val document: File, context: HtmlNodeRendererCon
   }
 
   private fun processLocalFileLocation(localFilePath: String): String {
-    val localPath = document.parent.replace("\\", "/").split("/").toMutableList()
+    val localPath = document
+      .parent
+      .replace("\\", urlSeparator)
+      .split(urlSeparator)
+      .toMutableList()
 
-    localFilePath.split("/").forEach {
-      if (it == "src/main") localPath.removeAt(localPath.size - 1)
+    localFilePath.split(urlSeparator).forEach {
+      if (it == "..") localPath.removeAt(localPath.size - 1)
       else localPath += it
     }
 
-    return localPath.joinToString("/")
+    return localPath.joinToString(urlSeparator)
   }
 
   private fun loadImageAttributes(

--- a/src/main/kotlin/com/github/woojiahao/modifiers/renderers/TaskListNodeRenderer.kt
+++ b/src/main/kotlin/com/github/woojiahao/modifiers/renderers/TaskListNodeRenderer.kt
@@ -52,8 +52,9 @@ class TaskListNodeRenderer(context: HtmlNodeRendererContext) : NodeRenderer {
 
         val isTaskCompleted = taskCompletionStatus.toLowerCase() == "x"
 
-        listItemContent.contents.forEachIndexed { index, paragraph ->
-          li("task-list-item") {
+        val checked = if (isTaskCompleted) "checked" else "unchecked"
+        li("task-list-item $checked") {
+          listItemContent.contents.forEachIndexed { index, paragraph ->
             p {
               if (index == 0) {
                 unsafe {


### PR DESCRIPTION
If bullet list has nested contents, contents won't render because I
overrode the behavior in my TaskListNodeRenderer, that bug is now fixed
and nested content will render appropriately